### PR TITLE
Consolidate style guides and update for 0.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ This has [several benefits](https://github.com/avh4/elm-format#elm-format),
 not the least of which is that it renders many potential style discussions moot,
 making it easier to spend more time building things!
 
-## Use descriptive names instead of apostrophes
+## Use descriptive names instead of underscores
 
 Instead of this:
 
@@ -125,10 +125,10 @@ Instead of this:
 -- Don't do this --
 markDirty model =
   let
-    model' =
+    model_ =
       { model | dirty = True }
   in
-    model'
+    model_
 ```
 
 ...just come up with a name.

--- a/README.md
+++ b/README.md
@@ -99,24 +99,6 @@ To summarize:
     - Imports Model and Update (for the action types)
 
 
-## Tooling
-
-### Use [`elm-init-scripts`](https://github.com/NoRedInk/elm-init-scripts) to start your projects
-
-This will generate all the files mentioned above for you.
-
-### Use [`elm-ops-tooling`](https://github.com/NoRedInk/elm-ops-tooling) to manage your projects
-
-In particular, use `elm_deps_sync` to keep your main elm-package.json in sync with your test elm-package.json.
-
-### Use [`elm-format`](https://github.com/avh4/elm-format) on all files
-
-We run the latest version of [`elm-format`](https://github.com/avh4/elm-format) to get uniform syntax formatting on our source code.
-
-This has [several benefits](https://github.com/avh4/elm-format#elm-format),
-not the least of which is that it renders many potential style discussions moot,
-making it easier to spend more time building things!
-
 ## Use descriptive names instead of underscores
 
 Instead of this:
@@ -286,3 +268,21 @@ raw JSON.
 - Having complicated imports hurts our compile time! I don't know what to say about this other than if you feel that there's something wrong with the top 40 lines of your module because of imports, then it might be time to move things out into another module. Trust your gut.
 
 - If your application has too many constructors for your Action type, consider refactoring. Large `case..of` statements hurts compile time. It might be possible that some of your constructors can be combined, for example `type Action = Open | Close` could actually be `type Action = SetOpenState Bool`
+
+## Tooling
+
+### Use [`elm-init-scripts`](https://github.com/NoRedInk/elm-init-scripts) to start your projects
+
+This will generate all the files mentioned above for you.
+
+### Use [`elm-ops-tooling`](https://github.com/NoRedInk/elm-ops-tooling) to manage your projects
+
+In particular, use `elm_deps_sync` to keep your main elm-package.json in sync with your test elm-package.json.
+
+### Use [`elm-format`](https://github.com/avh4/elm-format) on all files
+
+We run the latest version of [`elm-format`](https://github.com/avh4/elm-format) to get uniform syntax formatting on our source code.
+
+This has [several benefits](https://github.com/avh4/elm-format#elm-format),
+not the least of which is that it renders many potential style discussions moot,
+making it easier to spend more time building things!

--- a/README.md
+++ b/README.md
@@ -4,6 +4,20 @@ These are the guidelines we follow when writing [Elm](http://elm-lang.org) code 
 
 Note to NoRedInkers: These conventions have evolved over time, so there will always be some parts of the code base that don't follow everything. This is how we want to write new code, but there's no urgency around changing old code to conform. Feel free to clean up old code if you like, but don't feel obliged.
 
+
+## Table of Contents
+
+* [How to Namespace Modules](#how-to-namespace-modules)
+* [Page Structure](#page-structure)
+* [Ports](#ports)
+* [Model](#model)
+* [Naming](#naming)
+* [Function Composition](#function-composition)
+* [Syntax](#syntax)
+* [Code Smells](#code-smells)
+* [Tooling](#tooling)
+
+
 ## How to Namespace Modules
 
 ### `Nri.`

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ accounts
   |> Task.andThen (\response -> sendToLogger response.successMessage)
 ```
 
-## Use [`\_ ->`](http://elm-lang.org/docs/syntax#functions) over [`always`](http://package.elm-lang.org/packages/elm-lang/core/2.1.0/Basics#always)
+## Use [`\_ ->`](http://elm-lang.org/docs/syntax#functions) over [`always`](http://package.elm-lang.org/packages/elm-lang/core/latest/Basics#always)
 
 It's more concise, more recognizable as a function, and makes it easier to change your mind later and name the argument.
 
@@ -177,7 +177,7 @@ on "click" Json.value (always (Signal.message address ()))
 on "click" Json.value (\_ -> Signal.message address ())
 ```
 
-## Only use [`<|`](http://package.elm-lang.org/packages/elm-lang/core/2.1.0/Basics#<|) when parens would be awkward
+## Only use [`<|`](http://package.elm-lang.org/packages/elm-lang/core/latest/Basics#<|) when parens would be awkward
 
 Instead of this:
 
@@ -228,7 +228,7 @@ customDecoder string
           Result.Ok 3
 ```
 
-## Always use [`Json.Decode.Pipeline`](https://github.com/NoRedInk/elm-decode-pipeline) instead of [`objectN`](http://package.elm-lang.org/packages/elm-lang/core/2.1.0/Json-Decode#object2)
+## Always use [`Json.Decode.Pipeline`](https://github.com/NoRedInk/elm-decode-pipeline) instead of [`mapN`](http://package.elm-lang.org/packages/elm-lang/core/latest/Json-Decode#map2)
 
 Even though this would work...
 
@@ -236,7 +236,7 @@ Even though this would work...
 -- Don't do this --
 algoliaResult : Decoder AlgoliaResult
 algoliaResult =
-  object6 AlgoliaResult
+  map6 AlgoliaResult
     ("id" := int)
     ("name" := string)
     ("address" := string)

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ Something reusable that we might open source, that aren't tied directly to any N
 Make as much of this opensource-ready as possible:
 
 - Must have simple documentation explaining how to use the component. No need to go overboard, but it needs to be there. Imagine you're publishing the package on elm-package! Use `--warn` to get errors for missing documentation.
-- Expose the Model, the Action constructors, the Address pattern.
-- Use `type alias Model a = { a | b : c }` and `type alias Addresses a = { a | b : c }` to allow extending of things.
+- Expose the Model, the Msg constructors, the Address pattern.
+- Use `type alias Model a = { a | b : c }` to allow extending of things.
 - Provide an API file as example usage of the module.
 - Follow either the [elm-api-component](https://github.com/NoRedInk/elm-api-components) pattern, or the [elm-html-widgets](https://github.com/NoRedInk/elm-html-widgets) pattern
 
@@ -61,42 +61,41 @@ Make as much of this opensource-ready as possible:
 - Tabs component
 
 
-## Structure
+## Page Structure
 
 Our Elm apps generally take this form:
 
-- API.js.elm
+- Main.elm (API.js.elm for pages in 0.16)
 - Model.elm
 - Update.elm
 - View.elm
 
-API.js.elm is our entry file. Here, we import everything from the other files and actually connect everything together. We use a custom version of `StartApp`, that allows us to bootstrap our Elm program with data sent down from the server on load. We also setup the interop with JS in this file. Note the extension - API.js.elm. It has .js as it is the file that gets converted into JS! We run elm-make on this file to generate the component that we can include elsewhere.
+**`Main.elm`** is our entry file. Here, we import everything from the other files and actually connect everything together. We also setup ports for interop with JS in this file. We run elm-make on this file to generate a JS file that we can include elsewhere.
 
-Inside Model, we contain the actual model for the view state of our program. Sometimes, we include decoders for our model in here. Note that we generally don't include non-view state inside here, preferring to instead generalize things away from the view where possible. For example, we might have a record with a list of assignments in our Model file, but the assignment type itself would be in a general file called Assignment.elm.
+Inside **`Model.elm`**, we contain the actual model for the view state of our program. Sometimes, we include decoders for our model in here. Note that we generally don't include non-view state inside here, preferring to instead generalize things away from the view where possible. For example, we might have a record with a list of assignments in our `Model` file, but the assignment type itself would be in a module called `Data.Assignment`.
 
-Update.elm contains our update code. This includes the action types for our view. Inside here most of our business logic lives.
+**`Update.elm`** contains our update code. This includes the `Msg` types for our view. Inside here most of our business logic lives.
 
-Inside View.elm, we define the view for our model and set up calls to any action that we need to.
+Inside **`View.elm`**, we define the view for our model and set up any event handlers we need.
 
 To summarize:
 
-- API.js.elm
-    - Our entry point. Contains an initial model, startapp calls and ports.
-    - Compile target for elm-make
-    - Imports Model, Update and View.
+- Main.elm
+    - Our entry point. Contains an initial model, `Html.programWithFlags` calls and ports.
+    - Compile target for `elm-make`
+    - Imports `Model`, `Update` and `View`.
 
 - Model.elm
-    - Contains the Model type for the view alone.
+    - Contains the `Model` type for the view alone.
     - Imports nothing but generalized types that are used in the model
 
 - Update.elm
-    - Contains the Action type for the view, and the update function.
-    - Contains `addresses`
-    - Imports Model
+    - Contains the `Msg` type for the view, and the update function.
+    - Imports `Model`
 
 - View.elm
     - Contains the view code
-    - Imports Model and Update (for the action types)
+    - Imports `Model` and `Update` (for the `Msg` types)
 
 
 ## Use descriptive names instead of underscores

--- a/README.md
+++ b/README.md
@@ -253,12 +253,12 @@ Even though this would work...
 algoliaResult : Decoder AlgoliaResult
 algoliaResult =
   map6 AlgoliaResult
-    ("id" := int)
-    ("name" := string)
-    ("address" := string)
-    ("city" := string)
-    ("state" := string)
-    ("zip" := string)
+    (field "id" int)
+    (field "name" string)
+    (field "address" string)
+    (field "city" string)
+    (field "state" string)
+    (field "zip" string)
 ```
 
 ...it's inconsistent with the longer decoders, and must be refactored if we want to add more fields.

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ raw JSON.
 
 Having complicated imports hurts our compile time! I don't know what to say about this other than if you feel that there's something wrong with the top 40 lines of your module because of imports, then it might be time to move things out into another module. Trust your gut.
 
-### If a function can be pulled outside of a let binding, then do it.
+### If a function can be pulled outside of a let binding, then do it
 
 Giant let bindings hurt readability and performance. The less nested a function, the less functions are used in generated code.
 

--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ Large `case..of` statements hurts compile time. It might be possible that some o
 
 ### Use [`elm-init-scripts`](https://github.com/NoRedInk/elm-init-scripts) to start your projects
 
-This will generate all the files mentioned above for you.
+This will generate all the files mentioned [above](#how-to-structure-modules-for-a-page) for you.
 
 ### Use [`elm-ops-tooling`](https://github.com/NoRedInk/elm-ops-tooling) to manage your projects
 

--- a/README.md
+++ b/README.md
@@ -5,47 +5,54 @@ These are the guidelines we follow when writing [Elm](http://elm-lang.org) code 
 Note to NoRedInkers: These conventions have evolved over time, so there will always be some parts of the code base that don't follow everything. This is how we want to write new code, but there's no urgency around changing old code to conform. Feel free to clean up old code if you like, but don't feel obliged.
 
 
-## Internal namespacing
+## How to Name Modules
 
-### Namespace Component
-- `Component`
-- Reusable things, could be made open source, that aren't tied directly to any NRI stuff
-- make as much of this open source as possible
-- Must have simple documentation explaining how to use the component. No need to go overboard, but it needs to be there. Imagine you're publishing the package on elm-package! Use `--warn` to get errors for missing documentation
-- Expose the Model, the Action constructors, the Address pattern.
-- Use `type alias Model a = { a | b : c }` and `type alias Addresses a = { a | b : c }` to allow extending of things
-- Provide an API file as example usage of the component
+### `Nri`
+`Nri.Button`, `Nri.Emoji`, `Nri.PremiumUpsell`
+- A reusable part of the site's look and feel, which could go in this style guide. While some parts could be made open source, these are tied directly to NRI stuff.
 
-#### Examples
-- Filter component
-- Long polling component
-- tabs component
-- new things going into `Component` should be either following the [elm-api-component](https://github.com/NoRedInk/elm-api-components) pattern, or the [elm-html-widgets](https://github.com/NoRedInk/elm-html-widgets) pattern
-
-
-### Namespace Nri
-- `Nri`
-- Reusable things, some parts could be made open source, but are tied directly to NRI stuff
-- Like component but internal.
-- Abstractions of data types could go in here.
 - When adding a new abstraction to Nri, announce it on slack and seek as much feedback as possible! this will be used in multiple places.
 
 #### Examples
-- Data types for a concept shared between multiple views (e.g `StudentTask`)
-- helpers for those data types
 - NRI styling (elm-css colors)
-- `Nri.StudentTask`, `Nri.Stylers`
-- A type that represents a "base" type record definition. A simple example might be a student, which you will then extend in `Page` (see below)
+- `Nri.Stylers`
 
 
-### Namespace Page
-- `Page`
-- Pages, not reusable, implemented using a combination of types from `Nri` and components from `Component`
+### `Data`
+`Data.Assignment`, `Data.Course`, `Data.User`
+
+- Data (and functions related to that data) shared across multiple pages.
+
+#### Examples
+- Data types for a concept shared between multiple views (e.g `Data.StudentTask`)
+- Helpers for those data types
+- A type that represents a "base" type record definition. A simple example might be a `Student`, which you will then extend in `Page` (see below)
+
+### `Page`
+`Page.Writing.Rate.Main`, `Page.Writing.Rate.Update`, `Page.Writing.Rate.Model.Decoder`
+- A page on the site, which has its own URL. These are not reusable, and implemented using a combination of types from `Data` and components from `Nri`.
 - Comments for usage instructions aren't required, as code isn't intended to be reusable.
 
 #### Examples
 - Entry points for our particular pages.
-- non-reusable stuff live here
+
+
+### Top-level modules
+`Accordion`, `Dropdown`
+
+- Something reusable that we might open source, that aren't tied directly to any NRI stuff. Name it what we'd name it if we'd already open-sourced it.
+- Make as much of this open source as possible
+- Must have simple documentation explaining how to use the component. No need to go overboard, but it needs to be there. Imagine you're publishing the package on elm-package! Use `--warn` to get errors for missing documentation
+- Expose the Model, the Action constructors, the Address pattern.
+- Use `type alias Model a = { a | b : c }` and `type alias Addresses a = { a | b : c }` to allow extending of things
+- Provide an API file as example usage of the module
+
+#### Examples
+- Filter component
+- Long polling component
+- Tabs component
+- New things going into the top level namespace should be either following the [elm-api-component](https://github.com/NoRedInk/elm-api-components) pattern, or the [elm-html-widgets](https://github.com/NoRedInk/elm-html-widgets) pattern
+
 
 ## Structure
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Note to NoRedInkers: These conventions have evolved over time, so there will alw
 ## Table of Contents
 
 * [How to Namespace Modules](#how-to-namespace-modules)
-* [Page Structure](#page-structure)
+* [How to Structure Modules for A Page](#how-to-structure-modules-for-a-page)
 * [Ports](#ports)
 * [Model](#model)
 * [Naming](#naming)
@@ -74,7 +74,7 @@ Make as much of this opensource-ready as possible:
 - Tabs component
 
 
-## Page Structure
+## How to Structure Modules for A Page
 
 Our Elm apps generally take this form:
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,9 @@ These are the guidelines we follow when writing [Elm](http://elm-lang.org) code 
 
 Note to NoRedInkers: These conventions have evolved over time, so there will always be some parts of the code base that don't follow everything. This is how we want to write new code, but there's no urgency around changing old code to conform. Feel free to clean up old code if you like, but don't feel obliged.
 
+## How to Namespace Modules
 
-## How to Name Modules
-
-### `Nri`
+### `Nri.`
 `Nri.Button`, `Nri.Emoji`, `Nri.Leaderboard`
 
 A reusable part of the site's look and feel, which could go in the visual style guide. While some parts could be made open source, these are tied directly to NRI stuff.
@@ -21,7 +20,7 @@ When adding a new abstraction to Nri, announce it on slack and seek as much feed
 - `elm-css` colors and fonts should go in [here](https://github.com/NoRedInk/nri-elm-css)
 
 
-### `Data`
+### `Data.`
 `Data.Assignment`, `Data.Course`, `Data.User`
 
 Data (and functions related to that data) shared across multiple pages.
@@ -31,7 +30,7 @@ Data (and functions related to that data) shared across multiple pages.
 - A type that represents a "base" type record definition. A simple example might be a `Student`, which you will then extend in `Page` (see below)
 - Helpers for those data types
 
-### `Page`
+### `Page.`
 `Page.Writing.Rate.Main`, `Page.Writing.Rate.Update`, `Page.Writing.Rate.Model.Decoder`
 
 A page on the site, which has its own URL. These are not reusable, and implemented using a combination of types from `Data` and components from `Nri`.

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ markDirty model =
     dirtyModel
 ```
 
-## Use [`flip`](http://package.elm-lang.org/packages/elm-lang/core/2.1.0/Basics#flip) and/or pipes over backticks
+## Use pipes over backticks
 
 Instead of this:
 
@@ -153,14 +153,14 @@ saveAccounts (List.map deactivateAccount accounts)
   `andThen` (\response -> sendToLogger response.successMessage)
 ```
 
-...use [`|>`](http://package.elm-lang.org/packages/elm-lang/core/2.1.0/Basics#|>) and qualified names like normal, and use `flip` to obtain the desired argument order.
+...use [`|>`](http://package.elm-lang.org/packages/elm-lang/core/latest/Basics#|>) and qualified names like normal, and use [`flip`](http://package.elm-lang.org/packages/elm-lang/core/latest/Basics#flip) to obtain the desired argument order.
 
 ```elm
 -- Instead do this --
 accounts
   |> List.map deactivateAccount
   |> saveAccounts
-  |> (flip Task.andThen) (\response -> sendToLogger response.successMessage)
+  |> Task.andThen (\response -> sendToLogger response.successMessage)
 ```
 
 ## Use [`\_ ->`](http://elm-lang.org/docs/syntax#functions) over [`always`](http://package.elm-lang.org/packages/elm-lang/core/2.1.0/Basics#always)

--- a/README.md
+++ b/README.md
@@ -8,30 +8,35 @@ Note to NoRedInkers: These conventions have evolved over time, so there will alw
 ## How to Name Modules
 
 ### `Nri`
-`Nri.Button`, `Nri.Emoji`, `Nri.PremiumUpsell`
-- A reusable part of the site's look and feel, which could go in this style guide. While some parts could be made open source, these are tied directly to NRI stuff.
+`Nri.Button`, `Nri.Emoji`, `Nri.Leaderboard`
 
-- When adding a new abstraction to Nri, announce it on slack and seek as much feedback as possible! this will be used in multiple places.
+A reusable part of the site's look and feel, which could go in the visual style guide. While some parts could be made open source, these are tied directly to NRI stuff.
+
+When adding a new abstraction to Nri, announce it on slack and seek as much feedback as possible! this will be used in multiple places.
 
 #### Examples
-- NRI styling (elm-css colors)
-- `Nri.Stylers`
+- Common navigation header with configurable buttons
+
+#### Non-examples
+- `elm-css` colors and fonts should go in [here](https://github.com/NoRedInk/nri-elm-css)
 
 
 ### `Data`
 `Data.Assignment`, `Data.Course`, `Data.User`
 
-- Data (and functions related to that data) shared across multiple pages.
+Data (and functions related to that data) shared across multiple pages.
 
 #### Examples
 - Data types for a concept shared between multiple views (e.g `Data.StudentTask`)
-- Helpers for those data types
 - A type that represents a "base" type record definition. A simple example might be a `Student`, which you will then extend in `Page` (see below)
+- Helpers for those data types
 
 ### `Page`
 `Page.Writing.Rate.Main`, `Page.Writing.Rate.Update`, `Page.Writing.Rate.Model.Decoder`
-- A page on the site, which has its own URL. These are not reusable, and implemented using a combination of types from `Data` and components from `Nri`.
-- Comments for usage instructions aren't required, as code isn't intended to be reusable.
+
+A page on the site, which has its own URL. These are not reusable, and implemented using a combination of types from `Data` and components from `Nri`.
+
+Comments for usage instructions aren't required, as code isn't intended to be reusable.
 
 #### Examples
 - Entry points for our particular pages.
@@ -40,18 +45,20 @@ Note to NoRedInkers: These conventions have evolved over time, so there will alw
 ### Top-level modules
 `Accordion`, `Dropdown`
 
-- Something reusable that we might open source, that aren't tied directly to any NRI stuff. Name it what we'd name it if we'd already open-sourced it.
-- Make as much of this open source as possible
-- Must have simple documentation explaining how to use the component. No need to go overboard, but it needs to be there. Imagine you're publishing the package on elm-package! Use `--warn` to get errors for missing documentation
+Something reusable that we might open source, that aren't tied directly to any NRI stuff. Name it what we'd name it if we'd already open-sourced it.
+
+Make as much of this opensource-ready as possible:
+
+- Must have simple documentation explaining how to use the component. No need to go overboard, but it needs to be there. Imagine you're publishing the package on elm-package! Use `--warn` to get errors for missing documentation.
 - Expose the Model, the Action constructors, the Address pattern.
-- Use `type alias Model a = { a | b : c }` and `type alias Addresses a = { a | b : c }` to allow extending of things
-- Provide an API file as example usage of the module
+- Use `type alias Model a = { a | b : c }` and `type alias Addresses a = { a | b : c }` to allow extending of things.
+- Provide an API file as example usage of the module.
+- Follow either the [elm-api-component](https://github.com/NoRedInk/elm-api-components) pattern, or the [elm-html-widgets](https://github.com/NoRedInk/elm-html-widgets) pattern
 
 #### Examples
 - Filter component
 - Long polling component
 - Tabs component
-- New things going into the top level namespace should be either following the [elm-api-component](https://github.com/NoRedInk/elm-api-components) pattern, or the [elm-html-widgets](https://github.com/NoRedInk/elm-html-widgets) pattern
 
 
 ## Structure

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Something reusable that we might open source, that aren't tied directly to any N
 Make as much of this opensource-ready as possible:
 
 - Must have simple documentation explaining how to use the component. No need to go overboard, but it needs to be there. Imagine you're publishing the package on elm-package! Use `--warn` to get errors for missing documentation.
-- Expose the Model, the Msg constructors, the Address pattern.
+- Expose Model and the Msg constructors.
 - Use `type alias Model a = { a | b : c }` to allow extending of things.
 - Provide an API file as example usage of the module.
 - Follow either the [elm-api-component](https://github.com/NoRedInk/elm-api-components) pattern, or the [elm-html-widgets](https://github.com/NoRedInk/elm-html-widgets) pattern


### PR DESCRIPTION
As our style guide evolved, it left bits and pieces of itself in our internal documentation space. This PR unifies them and further brings it up-to-date with Elm 0.18 practices.