### PR TITLE
Add how to structure modules for a component

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ When the module gets more complex, break out each of the Elm architecture triad 
 
 Introduce `Flags.elm` (see below) and other submodules as necessary.
 
+We don't have a metric to determine exactly when to move from a single-file module to a multi-file module: trust your gut feelings and aesthetics.
+
 ### Anti-pattern
 
 Don't do: `Nri/Leaderboard/Main.elm` - the filename `Main.elm` is reserved for entrypoints under the `Page` namespace, so that we can run an automatic check during CI, which enforces the [stricter naming convention for modules under `Page`](./#examples-2).

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Note to NoRedInkers: These conventions have evolved over time, so there will alw
 ## Table of Contents
 
 * [How to Namespace Modules](#how-to-namespace-modules)
-* [How to Structure Modules for A Component](#how-to-structure-modules-for-a-component)
+* [How to Structure Modules for Reuse](#how-to-structure-modules-for-reuse)
 * [How to Structure Modules for A Page](#how-to-structure-modules-for-a-page)
 * [Ports](#ports)
 * [Model](#model)
@@ -28,7 +28,7 @@ A reusable part of the site's look and feel, which could go in the visual style 
 
 When adding a new abstraction to Nri, announce it on slack and seek as much feedback as possible! this will be used in multiple places.
 
-Further breakdown of the module is subject to [How to Structure Modules for A Component](#how-to-structure-modules-for-a-component).
+Further breakdown of the module is subject to [How to Structure Modules for Reuse](#how-to-structure-modules-for-reuse).
 
 #### Examples
 - Common navigation header with configurable buttons
@@ -50,7 +50,7 @@ Data (and functions related to that data) shared across multiple pages.
 ### `Page.`
 `Page.Writing.Rate.Main`, `Page.Writing.Rate.Update`, `Page.Writing.Rate.Model.Decoder`
 
-A page on the site, which has its own URL. These are not reusable, and implemented using a combination of types from `Data` and components from `Nri`.
+A page on the site, which has its own URL. These are not reusable, and implemented using a combination of types from `Data` and modules from `Nri`.
 
 The module name should follow the URL. Naming after the URL is subject to [How to Structure Modules for A Page](#how-to-structure-modules-for-a-page). The purpose of this convention is so when you have a URL, you can easily figure out where to find the module.
 
@@ -72,7 +72,7 @@ Something reusable that we might open source, that aren't tied directly to any N
 
 Make as much of this opensource-ready as possible:
 
-- Must have simple documentation explaining how to use the component. No need to go overboard, but it needs to be there. Imagine you're publishing the package on elm-package! Use `--warn` to get errors for missing documentation.
+- Must have simple documentation explaining how to use the module. No need to go overboard, but it needs to be there. Imagine you're publishing the package on elm-package! Use `--warn` to get errors for missing documentation.
 - Expose Model and the Msg constructors.
 - Use `type alias Model a = { a | b : c }` to allow extending of things.
 - Provide an API file as example usage of the module.
@@ -84,16 +84,14 @@ Make as much of this opensource-ready as possible:
 - Tabs component
 
 
-## How to Structure Modules for A Component
+## How to Structure Modules for Reuse
 
-We use "component" here in its loosest sense: ranging from a reusable view function to a pluggable trio of model/view/update functions.
-
-When the component is small enough, it's fine to let a single module hold all relevant code:
+When the module is small enough, it's fine to let a single file hold all relevant code:
 
 - Nri/
   - Button.elm
 
-When the component gets more complex, break out each of the Elm architecture triad into its own file:
+When the module gets more complex, break out each of the Elm architecture triad into its own file while keeping the top-level Elm file as the public interface to import:
 
 - Nri/
   - Leaderboard.elm -- Expose Model, init, view, update, and other types/functions necessary for use
@@ -102,7 +100,7 @@ When the component gets more complex, break out each of the Elm architecture tri
     - Update.elm
     - View.elm
 
-Introduce `Flags.elm` (see below) and further subcomponents as necessary.
+Introduce `Flags.elm` (see below) and other submodules as necessary.
 
 ## How to Structure Modules for A Page
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,11 @@ When the module gets more complex, break out each of the Elm architecture triad 
 
 Introduce `Flags.elm` (see below) and other submodules as necessary.
 
+### Anti-pattern
+
+Don't do: `Nri/Leaderboard/Main.elm` - the filename `Main.elm` is reserved for entrypoints under the `Page` namespace, so that we can run an automatic check during CI, which enforces the [stricter naming convention for modules under `Page`](./#examples-2).
+
+
 ## How to Structure Modules for A Page
 
 Our Elm apps generally take this form:

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Note to NoRedInkers: These conventions have evolved over time, so there will alw
 ## Table of Contents
 
 * [How to Namespace Modules](#how-to-namespace-modules)
+* [How to Structure Modules for A Component](#how-to-structure-modules-for-a-component)
 * [How to Structure Modules for A Page](#how-to-structure-modules-for-a-page)
 * [Ports](#ports)
 * [Model](#model)
@@ -26,6 +27,8 @@ Note to NoRedInkers: These conventions have evolved over time, so there will alw
 A reusable part of the site's look and feel, which could go in the visual style guide. While some parts could be made open source, these are tied directly to NRI stuff.
 
 When adding a new abstraction to Nri, announce it on slack and seek as much feedback as possible! this will be used in multiple places.
+
+Further breakdown of the module is subject to [How to Structure Modules for A Component](#how-to-structure-modules-for-a-component).
 
 #### Examples
 - Common navigation header with configurable buttons
@@ -80,6 +83,26 @@ Make as much of this opensource-ready as possible:
 - Long polling component
 - Tabs component
 
+
+## How to Structure Modules for A Component
+
+We use "component" here in its loosest sense: ranging from a reusable view function to a pluggable trio of model/view/update functions.
+
+When the component is small enough, it's fine to let a single module hold all relevant code:
+
+- Nri/
+  - Button.elm
+
+When the component gets more complex, break out each of the Elm architecture triad into its own file:
+
+- Nri/
+  - Leaderboard.elm -- Expose Model, init, view, update, and other types/functions necessary for use
+  - Leaderboard/
+    - Model.elm
+    - Update.elm
+    - View.elm
+
+Introduce `Flags.elm` (see below) and further subcomponents as necessary.
 
 ## How to Structure Modules for A Page
 


### PR DESCRIPTION
Motivation: we want to keep the filename `Main.elm` reserved for a full-fledged program that governs a page, so that we can lint and enforce the naming convention laid out in this style guide.