### PR TITLE
Update Json.Decode.Pipeline link to moved repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ customDecoder string
           Result.Ok 3
 ```
 
-### Always use [`Json.Decode.Pipeline`](https://github.com/NoRedInk/elm-decode-pipeline) instead of [`mapN`](http://package.elm-lang.org/packages/elm-lang/core/latest/Json-Decode#map2)
+### Always use [`Json.Decode.Pipeline`](https://github.com/NoRedInk/elm-json-decode-pipeline) instead of [`mapN`](http://package.elm-lang.org/packages/elm-lang/core/latest/Json-Decode#map2)
 
 Even though this would work...
 


### PR DESCRIPTION
According to https://github.com/NoRedInk/elm-decode-pipeline:

> This package has moved!
> 
> Please see https://github.com/NoRedInk/elm-json-decode-pipeline for the current version.